### PR TITLE
Expand standings view to support multi-column manager scores

### DIFF
--- a/standings.html
+++ b/standings.html
@@ -138,6 +138,12 @@
         background: rgba(56, 189, 248, 0.18);
       }
 
+      .manager-main {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
       .manager-name {
         font-size: 1.05rem;
         font-weight: 600;
@@ -149,6 +155,52 @@
         font-weight: 700;
         color: var(--accent);
         letter-spacing: 0.02em;
+        white-space: nowrap;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .manager-score-label {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 8px;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 0.65rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 700;
+      }
+
+      .manager-breakdown {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .score-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(148, 163, 184, 0.15);
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+        font-weight: 500;
+      }
+
+      .score-pill__label {
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .score-pill__value {
+        font-weight: 600;
+        color: var(--text-primary);
       }
 
       .empty-state {
@@ -156,6 +208,69 @@
         padding: 48px 24px;
         color: var(--text-secondary);
         font-size: 1.05rem;
+      }
+
+      .scoreboard-table-wrapper {
+        margin-top: 28px;
+        border: 1px solid var(--card-border);
+        border-radius: 20px;
+        overflow: hidden;
+      }
+
+      .scoreboard-scroll {
+        overflow-x: auto;
+      }
+
+      .score-table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(15, 23, 42, 0.35);
+      }
+
+      .score-table thead {
+        background: var(--table-header-bg);
+        backdrop-filter: blur(8px);
+      }
+
+      .score-table th,
+      .score-table td {
+        padding: 14px 18px;
+        text-align: left;
+        border-bottom: 1px solid var(--table-border);
+      }
+
+      .score-table th {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-secondary);
+      }
+
+      .score-table tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      .score-table tbody tr:hover {
+        background: var(--table-row-hover);
+      }
+
+      .score-table td {
+        font-size: 0.95rem;
+        font-weight: 500;
+      }
+
+      .score-table th:first-child,
+      .score-table td:first-child {
+        position: sticky;
+        left: 0;
+        background: inherit;
+        backdrop-filter: blur(8px);
+        z-index: 1;
+      }
+
+      .is-primary-score {
+        color: var(--accent);
+        font-weight: 700;
       }
 
       footer {
@@ -187,6 +302,18 @@
         .manager-score {
           font-size: 1.05rem;
         }
+        .manager-main {
+          gap: 6px;
+        }
+
+        .manager-breakdown {
+          gap: 6px;
+        }
+
+        .score-table th,
+        .score-table td {
+          padding: 12px 14px;
+        }
       }
     </style>
   </head>
@@ -201,19 +328,114 @@
       </header>
 
       <section class="card">
-        <? const managerScores = (typeof managerScores !== 'undefined' && Array.isArray(managerScores)) ? managerScores : []; ?>
-        <? if (managerScores.length === 0) { ?>
+        <?
+          const managerData = (managerScores && typeof managerScores === 'object' && Array.isArray(managerScores.entries))
+            ? managerScores
+            : {
+                headers: [],
+                managerColumnIndex: -1,
+                scoreColumnIndex: -1,
+                entries: Array.isArray(managerScores) ? managerScores : []
+              };
+          const entries = Array.isArray(managerData.entries) ? managerData.entries : [];
+          const headers = Array.isArray(managerData.headers) ? managerData.headers : [];
+          const managerColumnIndex = (typeof managerData.managerColumnIndex === 'number') ? managerData.managerColumnIndex : -1;
+          const scoreColumnIndex = (typeof managerData.scoreColumnIndex === 'number') ? managerData.scoreColumnIndex : -1;
+          const allColumns = headers.map(function(header, idx) {
+            var label = (header && header.toString().trim() !== '') ? header : ('Column ' + (idx + 1));
+            return { label: label, index: idx };
+          });
+          const detailColumns = allColumns.filter(function(column) {
+            return column.index !== managerColumnIndex;
+          }).filter(function(column) {
+            return entries.some(function(entry) {
+              var row = Array.isArray(entry.row) ? entry.row : [];
+              var value = (column.index >= 0 && column.index < row.length) ? row[column.index] : '';
+              if (value === null || typeof value === 'undefined') {
+                return false;
+              }
+              if (typeof value === 'string') {
+                return value.trim() !== '';
+              }
+              return value !== '';
+            });
+          });
+          var primaryColumn = null;
+          if (scoreColumnIndex !== -1) {
+            primaryColumn = detailColumns.find(function(column) { return column.index === scoreColumnIndex; }) || null;
+          }
+          if (!primaryColumn && detailColumns.length > 0) {
+            primaryColumn = detailColumns[0];
+          }
+          const secondaryColumns = primaryColumn
+            ? detailColumns.filter(function(column) { return column.index !== primaryColumn.index; })
+            : detailColumns;
+        ?>
+        <? if (entries.length === 0) { ?>
           <div class="empty-state">
             No manager standings are available right now. Check back soon!
           </div>
         <? } else { ?>
           <ul class="manager-list">
-            <? managerScores.forEach(function(entry) { ?>
+            <? entries.forEach(function(rawEntry) {
+                 var entry = (rawEntry && typeof rawEntry === 'object') ? rawEntry : { name: rawEntry, score: '', row: [] };
+                 var row = Array.isArray(entry.row) ? entry.row : [];
+                 var primaryValue = null;
+                 var hasPrimaryValue = false;
+                 if (primaryColumn) {
+                   primaryValue = (primaryColumn.index >= 0 && primaryColumn.index < row.length) ? row[primaryColumn.index] : '';
+                   if (primaryValue === null || typeof primaryValue === 'undefined') {
+                     primaryValue = '';
+                   }
+                   if (typeof primaryValue === 'string') {
+                     hasPrimaryValue = primaryValue.trim() !== '';
+                   } else {
+                     hasPrimaryValue = primaryValue !== '';
+                   }
+                 }
+                 var scoreValue = (typeof entry.score !== 'undefined') ? entry.score : '';
+                 var displayScore = hasPrimaryValue ? primaryValue : (scoreValue || scoreValue === 0 ? scoreValue : '');
+                 var hasDisplayScore = false;
+                 if (typeof displayScore === 'string') {
+                   hasDisplayScore = displayScore.trim() !== '';
+                 } else {
+                   hasDisplayScore = displayScore !== '' && displayScore !== null && typeof displayScore !== 'undefined';
+                 }
+            ?>
               <li class="manager-item">
-                <span class="manager-name"><?!= entry.name ?></span>
+                <div class="manager-main">
+                  <span class="manager-name"><?!= entry.name ?></span>
+                  <? if (secondaryColumns.length > 0) { ?>
+                    <div class="manager-breakdown">
+                      <? secondaryColumns.forEach(function(column) {
+                           var columnValue = (column.index >= 0 && column.index < row.length) ? row[column.index] : '';
+                           if (columnValue === null || typeof columnValue === 'undefined') {
+                             columnValue = '';
+                           }
+                           var hasValue = false;
+                           if (typeof columnValue === 'string') {
+                             hasValue = columnValue.trim() !== '';
+                           } else {
+                             hasValue = columnValue !== '';
+                           }
+                           if (!hasValue) {
+                             return;
+                           }
+                      ?>
+                        <span class="score-pill">
+                          <span class="score-pill__label"><?!= column.label ?></span>
+                          <span class="score-pill__value"><?!= columnValue ?></span>
+                        </span>
+                      <? }); ?>
+                    </div>
+                  <? } ?>
+                </div>
                 <span class="manager-score">
-                  <? if (entry.score || entry.score === 0) { ?>
-                    <?!= entry.score ?>
+                  <? if (primaryColumn) { ?>
+                    <span class="manager-score-label"><?!= primaryColumn.label ?></span>
+                  <? } ?>
+                  <? if (hasDisplayScore) { ?>
+                    <?!= displayScore ?>
                   <? } else { ?>
                     &mdash;
                   <? } ?>
@@ -221,6 +443,64 @@
               </li>
             <? }); ?>
           </ul>
+          <? if (detailColumns.length > 0) { ?>
+            <div class="scoreboard-table-wrapper">
+              <div class="scoreboard-scroll">
+                <table class="score-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Manager</th>
+                    <? detailColumns.forEach(function(column) { ?>
+                      <th scope="col" class="<?!= (column.index === scoreColumnIndex) ? 'is-primary-score' : '' ?>"><?!= column.label ?></th>
+                    <? }); ?>
+                  </tr>
+                </thead>
+                <tbody>
+                  <? entries.forEach(function(rawEntry) {
+                       var entry = (rawEntry && typeof rawEntry === 'object') ? rawEntry : { name: rawEntry, score: '', row: [] };
+                       var row = Array.isArray(entry.row) ? entry.row : [];
+                  ?>
+                    <tr>
+                      <th scope="row"><?!= entry.name ?></th>
+                      <? detailColumns.forEach(function(column) {
+                           var value = (column.index >= 0 && column.index < row.length) ? row[column.index] : '';
+                           if (value === null || typeof value === 'undefined') {
+                             value = '';
+                           }
+                           var hasValue = false;
+                           if (typeof value === 'string') {
+                             hasValue = value.trim() !== '';
+                           } else {
+                             hasValue = value !== '';
+                           }
+                           if (!hasValue && column.index === scoreColumnIndex) {
+                             var fallbackScore = (typeof entry.score !== 'undefined') ? entry.score : '';
+                             if (typeof fallbackScore === 'string') {
+                               if (fallbackScore.trim() !== '') {
+                                 value = fallbackScore;
+                                 hasValue = true;
+                               }
+                             } else if (fallbackScore !== '' && fallbackScore !== null && typeof fallbackScore !== 'undefined') {
+                               value = fallbackScore;
+                               hasValue = true;
+                             }
+                           }
+                      ?>
+                        <td class="<?!= (column.index === scoreColumnIndex) ? 'is-primary-score' : '' ?>">
+                          <? if (hasValue) { ?>
+                            <?!= value ?>
+                          <? } else { ?>
+                            &mdash;
+                          <? } ?>
+                        </td>
+                      <? }); ?>
+                    </tr>
+                  <? }); ?>
+                </tbody>
+                </table>
+              </div>
+            </div>
+          <? } ?>
         <? } ?>
       </section>
 


### PR DESCRIPTION
## Summary
- update the Apps Script helper to return manager entries with their full row data and column metadata
- enhance the standings page to surface additional score columns with chips and a responsive table view